### PR TITLE
feat(msg-box): added a service to show errors and other messages

### DIFF
--- a/client/src/services/index.ts
+++ b/client/src/services/index.ts
@@ -1,0 +1,3 @@
+import * as messageBox from './message-box';
+
+export {messageBox};

--- a/client/src/services/message-box.ts
+++ b/client/src/services/message-box.ts
@@ -1,0 +1,10 @@
+import {Alert} from 'react-native';
+
+export const info = (message: string) =>
+    Alert.alert('', message);
+
+export const warn = (message: string) =>
+    Alert.alert('Warning', message);
+
+export const error = (err: Error) =>
+    Alert.alert('Error', err.message);


### PR DESCRIPTION
closes #20 

does the job if we do not need a fancy message box. uses `error.message` which can be really uninformative at times.